### PR TITLE
refactor: splitted up those declarations for easier consumption

### DIFF
--- a/source/css/_fonts.general.scss
+++ b/source/css/_fonts.general.scss
@@ -1,0 +1,9 @@
+@import "db-ui-core.variables";
+
+%general-fonts {
+	font-family: $db-font-family-base;
+	color: $db-color-cool-gray-700;
+	font-size: 1rem;
+	font-weight: 400;
+	line-height: 1.5;
+}

--- a/source/css/db-ui-core.general.scss
+++ b/source/css/db-ui-core.general.scss
@@ -1,6 +1,7 @@
 @import "db-ui-core.variables";
 @import "@csstools/normalize.css/normalize";
 @import "../_patterns/00-base/init";
+@import "fonts.general";
 
 /* TODO: We most likely need to rework this */
 body,
@@ -9,9 +10,5 @@ button,
 input,
 select,
 textarea {
-	font-family: $db-font-family-base;
-	color: $db-color-cool-gray-700;
-	font-size: 1rem;
-	font-weight: 400;
-	line-height: 1.5;
+	@extend %general-fonts;
 }


### PR DESCRIPTION
Especially in DB UI Elements we'd like to consume the global declarations for fonts and more specifically declare those only to the scope of custom elements instead of `body, html` etc.

This change enables this exclusive consumption by extracting the declarations to another file.