### PR TITLE
refactor: let's release to npm

### DIFF
--- a/.github/scripts/publish-npm.sh
+++ b/.github/scripts/publish-npm.sh
@@ -39,5 +39,5 @@ do
     echo "Could not authenticate with $REGISTRY"
     exit 1
   fi
-  npm publish --dry-run --tag "$TAG" db-ui-core-"$VALID_SEMVER_VERSION".tgz
+  npm publish --tag "$TAG" db-ui-core-"$VALID_SEMVER_VERSION".tgz
 done


### PR DESCRIPTION
Removing the `dry-run` parameter from `npm publish` command within our CI/CD script.