### PR TITLE
feat: added internally accessible pages error page

### DIFF
--- a/source/_patterns/04-pages/error-internal-page.hbs
+++ b/source/_patterns/04-pages/error-internal-page.hbs
@@ -1,0 +1,4 @@
+{{> elements-image src='../../images/db_logo.svg' alt='Deutsche Bahn Logo' styleModifier='is-logo' width='58' height='40' }}
+
+<p>Diese Seite ist nur aus dem internen Bahn Netz verfügbar. Bitte verbinden Sie sich zunächst mit dem VPN.</p>
+<p>This page is only available internally. Please connect to our VPN first.</p>

--- a/source/_patterns/04-pages/error-internal-page.md
+++ b/source/_patterns/04-pages/error-internal-page.md
@@ -1,0 +1,6 @@
+---
+title: Error - Internal page
+hidden: true
+---
+
+This error page is mainly meant to get shown in case of somebody opening a webpage hosted only internally.


### PR DESCRIPTION
Added a page that is meant to be shown as an error page in case that someone tries to access an only internally available webpage outside of our VPN.