### PR TITLE
docs: further documentation on the SCSS load path

### DIFF
--- a/docs/getStarted.adoc
+++ b/docs/getStarted.adoc
@@ -58,6 +58,8 @@ This should add a new entry to your `package.json` file:
 @import "@db-ui/core/sources/css/enterprise/db-ui-core";
 ----
 
+### SCSS: `node_modules include path / load path
+
 Please keep in mind, that you would need to set your `include path` also known as `load path` depending on your setup for the sass compiler to find the correct `node_modules` folder, e.g. like the following (this is similar to how other frameworks and libraries like link:https://github.com/twbs/bootstrap-npm-starter/blob/main/package.json#L18[Bootstrap] are handling this):
 
 #### link:https://npmjs.com/sass[`sass` compiler]

--- a/docs/migrationGuide.adoc
+++ b/docs/migrationGuide.adoc
@@ -12,6 +12,8 @@ Especially the following aspects have changed through the various different rele
 
 Please note that we've switched from the deprecated link:https://www.npmjs.com/package/node-sass[`node-sass`] compiler to its successor link:https://www.npmjs.com/package/sass[`sass`]. As `sass` doesn't support the tilde (`~`) reference to your `node_modules` folder out of the box and there even also doesn't seem to be a general solution out there, we've removed that one, so that in case you're using our SCSS sources directly, you would need to provide your `node_modules` folder as a load path or include path (e.g. `--load-path=node_modules` on the `sass` CLI usage).
 
+You need to set the load path / include path depending on your SCSS compiler as described within our link:getStarted.adoc#scss-node_modules-include-path--load-path[getting started]
+
 Additionally we've deprecated the `@db-ui/core/sources/css/enterprise/db-ui-core-include` SCSS endpoint – please either `@import` the file `@db-ui/core/sources/css/rollup.assets-paths` or `@db-ui/core/sources/css/webpack.assets-paths` depending on your bundler, previous to `@import`ing `@db-ui/core/sources/css/enterprise/db-ui-core` directly from now on.
 
 ==== SCSS Helper functions


### PR DESCRIPTION
We could optimize the documentation on the necessary load path / include path within our documentation to lead the developers to the correct place (getting started).