### PR TITLE
refactor: correctly validate for default github created branch names

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "prepare": "node -e \"try { require('husky').install() } catch (e) {}\""
   },
   "validate-branch-name": {
-    "pattern": "((dbux-3)|(dependabot-)|^((test|feat|fix|chore|docs|refactor|style|ci|perf)\\-[a-zA-Z0-9\\-]+)$)",
+    "pattern": "((dbux-3)|(dependabot-)|^((test|feat|fix|chore|docs|refactor|style|ci|perf|[0-9]+)\\-[a-zA-Z0-9\\-]+)$)",
     "errorMsg": "There is something wrong with your branch name. You should rename your branch to a valid name and try again. See the Pattern below."
   },
   "keywords": [],


### PR DESCRIPTION
If a branch is being created for an issue through the GitHub UI, its branch name is starting with the issues number followed by the text. We should ensure that we even also support this within our branch name validation script.