### PR TITLE
refactor(progress): replaced output by label due to a11y testing

### DIFF
--- a/source/_patterns/01-elements/progress/progress.hbs
+++ b/source/_patterns/01-elements/progress/progress.hbs
@@ -1,5 +1,18 @@
 <div class="elm-progress">
-	<progress {{#if value}}value="{{ value }}" {{#if maximalvalue }} max="{{ maximalvalue }}" {{/if}}{{#if conic}}
-		style="--progress-conic: {{ value }}" {{/if}}{{/if}} id="{{ id }}"{{#if type}} data-type="{{type}}"{{/if }}></progress>
-	{{#if_eq type 'loader'}}{{#if value}}<output for="{{ id }}">{{ value }}{{ unit }}</output>{{/if}}{{/if_eq}}
+	<progress
+		{{#if value}}
+			value="{{ value }}"
+			{{#if maximalvalue }} max="{{ maximalvalue }}"{{/if}}
+			{{#if conic}} style="--progress-conic: {{ value }}"{{/if}}
+		{{/if}}
+		id="{{ id }}"
+		{{#if type}} data-type="{{type}}"{{/if }}
+		aria-describedby="{{ id }}-label"></progress>
+	{{#if_eq type 'loader'}}
+		{{#if value}}<label
+			for="{{ id }}"
+			id="{{ id }}-label"
+			aria-hidden="true">{{ value }}{{ unit }}</label>
+		{{/if}}
+	{{/if_eq}}
 </div>

--- a/source/_patterns/01-elements/progress/progress.json
+++ b/source/_patterns/01-elements/progress/progress.json
@@ -2,6 +2,6 @@
 	"value": "68",
 	"maximalvalue": "100",
 	"unit": "%",
-	"id": "progress-label-01",
+	"id": "progress-01",
 	"type": "loader"
 }

--- a/source/_patterns/01-elements/progress/progress.scss
+++ b/source/_patterns/01-elements/progress/progress.scss
@@ -96,7 +96,8 @@
 					background: none;
 				}
 
-				& + output {
+				& + output, // legacy; TODO: remove with the next major release
+				& + label {
 					align-items: center;
 					background: $progress-conic-inner-backgroundColor; // * TODO: possibly rework variable naming
 					border-radius: 50%;

--- a/source/_patterns/01-elements/progress/progress~circular-loader-dark-background.json
+++ b/source/_patterns/01-elements/progress/progress~circular-loader-dark-background.json
@@ -1,4 +1,4 @@
 {
-	"id": "progress-label-06",
+	"id": "progress-06",
 	"conic": true
 }

--- a/source/_patterns/01-elements/progress/progress~circular-loader.json
+++ b/source/_patterns/01-elements/progress/progress~circular-loader.json
@@ -1,4 +1,4 @@
 {
-	"id": "progress-label-04",
+	"id": "progress-04",
 	"conic": true
 }

--- a/source/_patterns/01-elements/progress/progress~dark-background.json
+++ b/source/_patterns/01-elements/progress/progress~dark-background.json
@@ -1,3 +1,3 @@
 {
-	"id": "progress-label-03"
+	"id": "progress-03"
 }

--- a/source/_patterns/01-elements/progress/progress~linear-spinner-indeterminate.json
+++ b/source/_patterns/01-elements/progress/progress~linear-spinner-indeterminate.json
@@ -1,5 +1,5 @@
 {
 	"value": "",
-	"id": "progress-label-08",
+	"id": "progress-08",
 	"type": "spinner"
 }

--- a/source/_patterns/01-elements/progress/progress~linear-spinner.json
+++ b/source/_patterns/01-elements/progress/progress~linear-spinner.json
@@ -1,5 +1,5 @@
 {
 	"value": "68",
-	"id": "progress-label-07",
+	"id": "progress-07",
 	"type": "spinner"
 }


### PR DESCRIPTION
Both inspired by [MDN technical documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/progress) and further individual testing through the diverse audio description by JAWS, NVDA, iOS Voiceover and Microsoft Windows screen reader we've chosen a pattern that works best in all of those, after trying several other combinations and markup.

We're not making this a breaking change for the moment, as everybody should be able to do these changes in between.