### PR TITLE
refactor: optimized dependabot settings

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,10 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+      time: "03:00"
+      timezone: "Europe/Berlin"
+    reviewers:
+      - "github-actions"
     pull-request-branch-name:
       separator: "-"
 
@@ -14,6 +18,10 @@ updates:
     open-pull-requests-limit: 10
     schedule:
       interval: "daily"
+      time: "03:00"
+      timezone: "Europe/Berlin"
+    reviewers:
+      - "github-actions"
     pull-request-branch-name:
       separator: "-"
     # https://github.com/dependabot/dependabot-core/issues/5226#issuecomment-1179434437


### PR DESCRIPTION
Check for updates early each day and only have GH configured actions as default reviewer for not getting disturbed during work.