### PR TITLE
refactor: added further font faces

### DIFF
--- a/source/_patterns/00-base/type/_fonts.variables.scss
+++ b/source/_patterns/00-base/type/_fonts.variables.scss
@@ -9,6 +9,14 @@ $font-families: (
 		"font-style": normal,
 		"font-local": true
 	),
+	"DB Screen Head Regular": (
+		"font-family": "DB Screen Head",
+		"font-filename": "dbscreenhead-regular",
+		// normal font weight
+		"font-weight": 400,
+		"font-style": normal,
+		"font-local": true
+	),
 	"DB Screen Head Black": (
 		"font-family": "DB Screen Head",
 		"font-filename": "dbscreenhead-black",
@@ -33,6 +41,20 @@ $font-families: (
 			"font-style": normal,
 			"font-local": true
 		),
+	"DB Screen Sans Medium": (
+		"font-family": "DB Screen Sans",
+		"font-filename": "dbscreensans-medium",
+		"font-weight": 500,
+		"font-style": normal,
+		"font-local": true
+	),
+	"DB Screen Sans Semibold": (
+		"font-family": "DB Screen Sans",
+		"font-filename": "dbscreensans-semibold",
+		"font-weight": 600,
+		"font-style": normal,
+		"font-local": true
+	),
 	"DB Screen Sans Bold": (
 		"font-family": "DB Screen Sans",
 		"font-filename": "dbscreensans-bold",


### PR DESCRIPTION
Added further font-faces:
- `DB Screen Head Regular` with a `font-weight` of `400`
- `DB Screen Sans Medium` with a `font-weight` of `500`
- `DB Screen Sans Semibold` with a `font-weight` of `600`

partly solves https://github.com/db-ui/core/issues/17