### PR TITLE
chore(badges): added crossorigin anonymous attribute

### DIFF
--- a/source/_patterns/01-elements/image/image.hbs
+++ b/source/_patterns/01-elements/image/image.hbs
@@ -10,7 +10,8 @@
 		<img src="{{ src }}" alt="{{ alt }}" width="{{ width }}" height="{{ height }}"
 			class="elm-image {{ styleModifier }}" {{#if role }} role="{{ role }}" {{/if }}{{#if lazy}} loading="lazy"
 			{{/if }}{{#if srcset}} srcset="{{ srcset }}" {{/if }} {{#if caption}} aria-labelledby="caption01" {{/if
-			}}{{#if elementtiming }} elementtiming="{{ elementtiming }}" {{/if }}>
+			}}{{#if elementtiming }} elementtiming="{{ elementtiming }}"{{/if }}
+			{{#if crossorigin }} crossorigin="{{ crossorigin }}"{{/if }}>
 		{{#if sources}}
 	</picture>{{/if }}
 	{{#if caption}}<figcaption id="caption01">{{ caption }}</figcaption>

--- a/source/_patterns/04-pages/intro.hbs
+++ b/source/_patterns/04-pages/intro.hbs
@@ -4,9 +4,9 @@
 		{{> elements-image src="../../images/db-ui-core_logo.png" alt="" width="48" height="48" }}
 		{{> elements-headline type='1' text='DB UI Core' }}
 
-		{{> elements-image src="https://img.shields.io/badge/License-Apache_2.0-blue.svg" alt="Apache 2.0 license badge" }}
-		<a href="https://npmjs.com/package/@db-ui/core" target="_blank" rel="noopener noreferrer">{{> elements-image src="https://img.shields.io/npm/v/@db-ui/core.svg?color=rgb%28237%2C%2028%2C%2036%29" alt="npm version" }}</a>
-		{{> elements-image src="https://img.shields.io/badge/Based%20on-DB%20Design%20System%20UX%20Guides%20%2B%20Standards-d7dce1.svg" alt="Based on DB UX Design System guidelines" }}
+		{{> elements-image src="https://img.shields.io/badge/License-Apache_2.0-blue.svg" alt="Apache 2.0 license badge" crossorigin="anonymous" }}
+		<a href="https://npmjs.com/package/@db-ui/core" target="_blank" rel="noopener noreferrer">{{> elements-image src="https://img.shields.io/npm/v/@db-ui/core.svg?color=rgb%28237%2C%2028%2C%2036%29" alt="npm version" crossorigin="anonymous" }}</a>
+		{{> elements-image src="https://img.shields.io/badge/Based%20on-DB%20Design%20System%20UX%20Guides%20%2B%20Standards-d7dce1.svg" alt="Based on DB UX Design System guidelines" crossorigin="anonymous" }}
 
 		<p lang="de">Personenverkehr und DB Systel führen ihre Design Systeme für Web in der Version 2.0 der Standard Web Components zusammen. Unser Ziel ist eine einheitliche Basis UX im Sinne der Modernen Ikone für Kunden und Mitarbeiteranwendungen. Um unser Design End 2 End von Konzeption über Design bis zur Implementierung konsistent zu halten, wird das DB UX Design System auch in Code von DB Systel und Reisendeninformation umgesetzt. Stay Tuned!</p>
 


### PR DESCRIPTION
Added the [`crossorigin=anonymous`](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/crossorigin)-attribute to our badges references:
> Request uses CORS headers and credentials flag is set to `'same-origin'`. There is no exchange of **user credentials** via cookies, client-side SSL certificates or HTTP authentication, unless destination is the same origin.