### PR TITLE
refactor: set pipelines and local node versions equally

### DIFF
--- a/.github/actions/npm-cache/action.yml
+++ b/.github/actions/npm-cache/action.yml
@@ -3,6 +3,19 @@ description: "Initialize NPM Cache"
 runs:
   using: "composite"
   steps:
+    - name: Setup Node version equally to our local development version
+      # pick the Node version to use and install it
+      # https://github.com/actions/setup-node
+      uses: actions/setup-node@v3
+      with:
+        node-version: 16
+
+    - name: Display node and npm version
+      if: steps.npm-cache.outputs.cache-hit != 'true'
+      run: |
+        node --version
+        npm --version
+
     - uses: actions/cache@v3
       id: "npm-cache" # use this to check for `cache-hit` ==> if: steps.npm-cache.outputs.cache-hit != 'true'
       with:

--- a/.github/actions/npm-cache/action.yml
+++ b/.github/actions/npm-cache/action.yml
@@ -11,7 +11,6 @@ runs:
         node-version: 16
 
     - name: Display node and npm version
-      if: steps.npm-cache.outputs.cache-hit != 'true'
       run: |
         node --version
         npm --version

--- a/.github/actions/npm-cache/action.yml
+++ b/.github/actions/npm-cache/action.yml
@@ -11,6 +11,7 @@ runs:
         node-version: 16
 
     - name: Display node and npm version
+      shell: bash
       run: |
         node --version
         npm --version

--- a/.github/workflows/00-init.yml
+++ b/.github/workflows/00-init.yml
@@ -14,6 +14,20 @@ jobs:
       - name: ⬇️ Checkout repo
         uses: actions/checkout@v3
 
+      - name: Setup node equally to our local development version
+        if: steps.npm-cache.outputs.cache-hit != 'true'
+        # pick the Node version to use and install it
+        # https://github.com/actions/setup-node
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16
+
+      - name: Display node and npm version
+        if: steps.npm-cache.outputs.cache-hit != 'true'
+        run: |
+          node --version
+          npm --version
+
       - name: 🔄 Init Cache Default
         uses: ./.github/actions/npm-cache
 

--- a/.github/workflows/00-init.yml
+++ b/.github/workflows/00-init.yml
@@ -14,20 +14,6 @@ jobs:
       - name: ⬇️ Checkout repo
         uses: actions/checkout@v3
 
-      - name: Setup node equally to our local development version
-        if: steps.npm-cache.outputs.cache-hit != 'true'
-        # pick the Node version to use and install it
-        # https://github.com/actions/setup-node
-        uses: actions/setup-node@v3
-        with:
-          node-version: 16
-
-      - name: Display node and npm version
-        if: steps.npm-cache.outputs.cache-hit != 'true'
-        run: |
-          node --version
-          npm --version
-
       - name: 🔄 Init Cache Default
         uses: ./.github/actions/npm-cache
 

--- a/.github/workflows/00-scan-secrets.yml
+++ b/.github/workflows/00-scan-secrets.yml
@@ -12,6 +12,20 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Setup node equally to our local development version
+        if: steps.npm-cache.outputs.cache-hit != 'true'
+        # pick the Node version to use and install it
+        # https://github.com/actions/setup-node
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16
+
+      - name: Display node and npm version
+        if: steps.npm-cache.outputs.cache-hit != 'true'
+        run: |
+          node --version
+          npm --version
+
       - name: ↔ Extract branch name
         uses: ./.github/actions/extract-branch
         id: extract_branch

--- a/.github/workflows/00-scan-secrets.yml
+++ b/.github/workflows/00-scan-secrets.yml
@@ -12,20 +12,6 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Setup node equally to our local development version
-        if: steps.npm-cache.outputs.cache-hit != 'true'
-        # pick the Node version to use and install it
-        # https://github.com/actions/setup-node
-        uses: actions/setup-node@v3
-        with:
-          node-version: 16
-
-      - name: Display node and npm version
-        if: steps.npm-cache.outputs.cache-hit != 'true'
-        run: |
-          node --version
-          npm --version
-
       - name: ↔ Extract branch name
         uses: ./.github/actions/extract-branch
         id: extract_branch

--- a/.github/workflows/01-build.yml
+++ b/.github/workflows/01-build.yml
@@ -11,20 +11,6 @@ jobs:
       - name: ⬇️ Checkout repo
         uses: actions/checkout@v3
 
-      - name: Setup node equally to our local development version
-        if: steps.npm-cache.outputs.cache-hit != 'true'
-        # pick the Node version to use and install it
-        # https://github.com/actions/setup-node
-        uses: actions/setup-node@v3
-        with:
-          node-version: 16
-
-      - name: Display node and npm version
-        if: steps.npm-cache.outputs.cache-hit != 'true'
-        run: |
-          node --version
-          npm --version
-
       - name: 🔄 Init Cache
         uses: ./.github/actions/npm-cache
 

--- a/.github/workflows/01-build.yml
+++ b/.github/workflows/01-build.yml
@@ -11,6 +11,20 @@ jobs:
       - name: ⬇️ Checkout repo
         uses: actions/checkout@v3
 
+      - name: Setup node equally to our local development version
+        if: steps.npm-cache.outputs.cache-hit != 'true'
+        # pick the Node version to use and install it
+        # https://github.com/actions/setup-node
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16
+
+      - name: Display node and npm version
+        if: steps.npm-cache.outputs.cache-hit != 'true'
+        run: |
+          node --version
+          npm --version
+
       - name: 🔄 Init Cache
         uses: ./.github/actions/npm-cache
 

--- a/.github/workflows/01-get-publish-version.yml
+++ b/.github/workflows/01-get-publish-version.yml
@@ -27,20 +27,6 @@ jobs:
       - name: ⬇ Checkout repo
         uses: actions/checkout@v3
 
-      - name: Setup node equally to our local development version
-        if: steps.npm-cache.outputs.cache-hit != 'true'
-        # pick the Node version to use and install it
-        # https://github.com/actions/setup-node
-        uses: actions/setup-node@v3
-        with:
-          node-version: 16
-
-      - name: Display node and npm version
-        if: steps.npm-cache.outputs.cache-hit != 'true'
-        run: |
-          node --version
-          npm --version
-
       - name: 🔄 Init Cache
         uses: ./.github/actions/npm-cache
 

--- a/.github/workflows/01-get-publish-version.yml
+++ b/.github/workflows/01-get-publish-version.yml
@@ -27,6 +27,20 @@ jobs:
       - name: ⬇ Checkout repo
         uses: actions/checkout@v3
 
+      - name: Setup node equally to our local development version
+        if: steps.npm-cache.outputs.cache-hit != 'true'
+        # pick the Node version to use and install it
+        # https://github.com/actions/setup-node
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16
+
+      - name: Display node and npm version
+        if: steps.npm-cache.outputs.cache-hit != 'true'
+        run: |
+          node --version
+          npm --version
+
       - name: 🔄 Init Cache
         uses: ./.github/actions/npm-cache
 

--- a/.github/workflows/01-lint.yml
+++ b/.github/workflows/01-lint.yml
@@ -11,20 +11,6 @@ jobs:
       - name: ⬇️ Checkout repo
         uses: actions/checkout@v3
 
-      - name: Setup node equally to our local development version
-        if: steps.npm-cache.outputs.cache-hit != 'true'
-        # pick the Node version to use and install it
-        # https://github.com/actions/setup-node
-        uses: actions/setup-node@v3
-        with:
-          node-version: 16
-
-      - name: Display node and npm version
-        if: steps.npm-cache.outputs.cache-hit != 'true'
-        run: |
-          node --version
-          npm --version
-
       - name: 🔄 Init Cache
         uses: ./.github/actions/npm-cache
 

--- a/.github/workflows/01-lint.yml
+++ b/.github/workflows/01-lint.yml
@@ -11,6 +11,20 @@ jobs:
       - name: ⬇️ Checkout repo
         uses: actions/checkout@v3
 
+      - name: Setup node equally to our local development version
+        if: steps.npm-cache.outputs.cache-hit != 'true'
+        # pick the Node version to use and install it
+        # https://github.com/actions/setup-node
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16
+
+      - name: Display node and npm version
+        if: steps.npm-cache.outputs.cache-hit != 'true'
+        run: |
+          node --version
+          npm --version
+
       - name: 🔄 Init Cache
         uses: ./.github/actions/npm-cache
 

--- a/.github/workflows/01-test.yml
+++ b/.github/workflows/01-test.yml
@@ -11,20 +11,6 @@ jobs:
       - name: ⬇️ Checkout repo
         uses: actions/checkout@v3
 
-      - name: Setup node equally to our local development version
-        if: steps.npm-cache.outputs.cache-hit != 'true'
-        # pick the Node version to use and install it
-        # https://github.com/actions/setup-node
-        uses: actions/setup-node@v3
-        with:
-          node-version: 16
-
-      - name: Display node and npm version
-        if: steps.npm-cache.outputs.cache-hit != 'true'
-        run: |
-          node --version
-          npm --version
-
       - name: 🔄 Init Cache
         uses: ./.github/actions/npm-cache
 

--- a/.github/workflows/01-test.yml
+++ b/.github/workflows/01-test.yml
@@ -11,6 +11,20 @@ jobs:
       - name: ⬇️ Checkout repo
         uses: actions/checkout@v3
 
+      - name: Setup node equally to our local development version
+        if: steps.npm-cache.outputs.cache-hit != 'true'
+        # pick the Node version to use and install it
+        # https://github.com/actions/setup-node
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16
+
+      - name: Display node and npm version
+        if: steps.npm-cache.outputs.cache-hit != 'true'
+        run: |
+          node --version
+          npm --version
+
       - name: 🔄 Init Cache
         uses: ./.github/actions/npm-cache
 

--- a/.github/workflows/02-deploy-gh-pages.yml
+++ b/.github/workflows/02-deploy-gh-pages.yml
@@ -23,20 +23,6 @@ jobs:
       - name: ⬇ Checkout repo
         uses: actions/checkout@v3
 
-      - name: Setup node equally to our local development version
-        if: steps.npm-cache.outputs.cache-hit != 'true'
-        # pick the Node version to use and install it
-        # https://github.com/actions/setup-node
-        uses: actions/setup-node@v3
-        with:
-          node-version: 16
-
-      - name: Display node and npm version
-        if: steps.npm-cache.outputs.cache-hit != 'true'
-        run: |
-          node --version
-          npm --version
-
       - name: 🔄 Init Cache
         uses: ./.github/actions/npm-cache
 

--- a/.github/workflows/02-deploy-gh-pages.yml
+++ b/.github/workflows/02-deploy-gh-pages.yml
@@ -23,6 +23,20 @@ jobs:
       - name: ⬇ Checkout repo
         uses: actions/checkout@v3
 
+      - name: Setup node equally to our local development version
+        if: steps.npm-cache.outputs.cache-hit != 'true'
+        # pick the Node version to use and install it
+        # https://github.com/actions/setup-node
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16
+
+      - name: Display node and npm version
+        if: steps.npm-cache.outputs.cache-hit != 'true'
+        run: |
+          node --version
+          npm --version
+
       - name: 🔄 Init Cache
         uses: ./.github/actions/npm-cache
 

--- a/.github/workflows/03-publish-packages.yml
+++ b/.github/workflows/03-publish-packages.yml
@@ -24,20 +24,6 @@ jobs:
       - name: ⬇ Checkout repo
         uses: actions/checkout@v3
 
-      - name: Setup node equally to our local development version
-        if: steps.npm-cache.outputs.cache-hit != 'true'
-        # pick the Node version to use and install it
-        # https://github.com/actions/setup-node
-        uses: actions/setup-node@v3
-        with:
-          node-version: 16
-
-      - name: Display node and npm version
-        if: steps.npm-cache.outputs.cache-hit != 'true'
-        run: |
-          node --version
-          npm --version
-
       - name: 🔄 Init Cache
         uses: ./.github/actions/npm-cache
 

--- a/.github/workflows/03-publish-packages.yml
+++ b/.github/workflows/03-publish-packages.yml
@@ -24,6 +24,20 @@ jobs:
       - name: ⬇ Checkout repo
         uses: actions/checkout@v3
 
+      - name: Setup node equally to our local development version
+        if: steps.npm-cache.outputs.cache-hit != 'true'
+        # pick the Node version to use and install it
+        # https://github.com/actions/setup-node
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16
+
+      - name: Display node and npm version
+        if: steps.npm-cache.outputs.cache-hit != 'true'
+        run: |
+          node --version
+          npm --version
+
       - name: 🔄 Init Cache
         uses: ./.github/actions/npm-cache
 

--- a/.github/workflows/99-add-url-comment.yml
+++ b/.github/workflows/99-add-url-comment.yml
@@ -11,20 +11,6 @@ jobs:
       - name: ⬇ Checkout repo
         uses: actions/checkout@v3
 
-      - name: Setup node equally to our local development version
-        if: steps.npm-cache.outputs.cache-hit != 'true'
-        # pick the Node version to use and install it
-        # https://github.com/actions/setup-node
-        uses: actions/setup-node@v3
-        with:
-          node-version: 16
-
-      - name: Display node and npm version
-        if: steps.npm-cache.outputs.cache-hit != 'true'
-        run: |
-          node --version
-          npm --version
-
       - name: 📡 Add comment
         uses: actions/github-script@v6
         with:

--- a/.github/workflows/99-add-url-comment.yml
+++ b/.github/workflows/99-add-url-comment.yml
@@ -11,6 +11,20 @@ jobs:
       - name: ⬇ Checkout repo
         uses: actions/checkout@v3
 
+      - name: Setup node equally to our local development version
+        if: steps.npm-cache.outputs.cache-hit != 'true'
+        # pick the Node version to use and install it
+        # https://github.com/actions/setup-node
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16
+
+      - name: Display node and npm version
+        if: steps.npm-cache.outputs.cache-hit != 'true'
+        run: |
+          node --version
+          npm --version
+
       - name: 📡 Add comment
         uses: actions/github-script@v6
         with:

--- a/.github/workflows/99-auto-update-pr.yml
+++ b/.github/workflows/99-auto-update-pr.yml
@@ -22,6 +22,20 @@ jobs:
       - name: ⬇️ Checkout repo
         uses: actions/checkout@v3
 
+      - name: Setup node equally to our local development version
+        if: steps.npm-cache.outputs.cache-hit != 'true'
+        # pick the Node version to use and install it
+        # https://github.com/actions/setup-node
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16
+
+      - name: Display node and npm version
+        if: steps.npm-cache.outputs.cache-hit != 'true'
+        run: |
+          node --version
+          npm --version
+
       - name: ↔ Create Pull Request
         uses: actions/github-script@v6
         id: create-pr

--- a/.github/workflows/99-auto-update-pr.yml
+++ b/.github/workflows/99-auto-update-pr.yml
@@ -22,20 +22,6 @@ jobs:
       - name: ⬇️ Checkout repo
         uses: actions/checkout@v3
 
-      - name: Setup node equally to our local development version
-        if: steps.npm-cache.outputs.cache-hit != 'true'
-        # pick the Node version to use and install it
-        # https://github.com/actions/setup-node
-        uses: actions/setup-node@v3
-        with:
-          node-version: 16
-
-      - name: Display node and npm version
-        if: steps.npm-cache.outputs.cache-hit != 'true'
-        run: |
-          node --version
-          npm --version
-
       - name: ↔ Create Pull Request
         uses: actions/github-script@v6
         id: create-pr

--- a/.github/workflows/99-codeql-analysis.yml
+++ b/.github/workflows/99-codeql-analysis.yml
@@ -16,6 +16,20 @@ jobs:
       - name: ⬇ Checkout repo
         uses: actions/checkout@v3
 
+      - name: Setup node equally to our local development version
+        if: steps.npm-cache.outputs.cache-hit != 'true'
+        # pick the Node version to use and install it
+        # https://github.com/actions/setup-node
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16
+
+      - name: Display node and npm version
+        if: steps.npm-cache.outputs.cache-hit != 'true'
+        run: |
+          node --version
+          npm --version
+
       - name: 🔄 Initialize CodeQL
         uses: github/codeql-action/init@v2
         with:

--- a/.github/workflows/99-codeql-analysis.yml
+++ b/.github/workflows/99-codeql-analysis.yml
@@ -16,20 +16,6 @@ jobs:
       - name: ⬇ Checkout repo
         uses: actions/checkout@v3
 
-      - name: Setup node equally to our local development version
-        if: steps.npm-cache.outputs.cache-hit != 'true'
-        # pick the Node version to use and install it
-        # https://github.com/actions/setup-node
-        uses: actions/setup-node@v3
-        with:
-          node-version: 16
-
-      - name: Display node and npm version
-        if: steps.npm-cache.outputs.cache-hit != 'true'
-        run: |
-          node --version
-          npm --version
-
       - name: 🔄 Initialize CodeQL
         uses: github/codeql-action/init@v2
         with:

--- a/.github/workflows/99-dependency-review.yml
+++ b/.github/workflows/99-dependency-review.yml
@@ -10,19 +10,5 @@ jobs:
       - name: ⬇ Checkout repo
         uses: actions/checkout@v3
 
-      - name: Setup node equally to our local development version
-        if: steps.npm-cache.outputs.cache-hit != 'true'
-        # pick the Node version to use and install it
-        # https://github.com/actions/setup-node
-        uses: actions/setup-node@v3
-        with:
-          node-version: 16
-
-      - name: Display node and npm version
-        if: steps.npm-cache.outputs.cache-hit != 'true'
-        run: |
-          node --version
-          npm --version
-
       - name: 🔎 Dependency Review
         uses: actions/dependency-review-action@v3

--- a/.github/workflows/99-dependency-review.yml
+++ b/.github/workflows/99-dependency-review.yml
@@ -9,5 +9,20 @@ jobs:
     steps:
       - name: ⬇ Checkout repo
         uses: actions/checkout@v3
+
+      - name: Setup node equally to our local development version
+        if: steps.npm-cache.outputs.cache-hit != 'true'
+        # pick the Node version to use and install it
+        # https://github.com/actions/setup-node
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16
+
+      - name: Display node and npm version
+        if: steps.npm-cache.outputs.cache-hit != 'true'
+        run: |
+          node --version
+          npm --version
+
       - name: 🔎 Dependency Review
         uses: actions/dependency-review-action@v3

--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -13,6 +13,20 @@ jobs:
       - name: ⬇ Checkout repo
         uses: actions/checkout@v3
 
+      - name: Setup node equally to our local development version
+        if: steps.npm-cache.outputs.cache-hit != 'true'
+        # pick the Node version to use and install it
+        # https://github.com/actions/setup-node
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16
+
+      - name: Display node and npm version
+        if: steps.npm-cache.outputs.cache-hit != 'true'
+        run: |
+          node --version
+          npm --version
+
       - name: 📥 Get gh-pages tar
         run: wget -q https://github.com/db-ui/core/tarball/gh-pages
 

--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -13,20 +13,6 @@ jobs:
       - name: ⬇ Checkout repo
         uses: actions/checkout@v3
 
-      - name: Setup node equally to our local development version
-        if: steps.npm-cache.outputs.cache-hit != 'true'
-        # pick the Node version to use and install it
-        # https://github.com/actions/setup-node
-        uses: actions/setup-node@v3
-        with:
-          node-version: 16
-
-      - name: Display node and npm version
-        if: steps.npm-cache.outputs.cache-hit != 'true'
-        run: |
-          node --version
-          npm --version
-
       - name: 📥 Get gh-pages tar
         run: wget -q https://github.com/db-ui/core/tarball/gh-pages
 


### PR DESCRIPTION
Not using the same Node version leads to problems in the pipeline that weren't occuring on localhost, like e.g. the following in DB UI Elements repository: https://github.com/db-ui/elements/actions/runs/4220820918/jobs/7327485768

We're using the `init cache` action as the basis as this perfectly separates workflows / workflow steps that we even also run locally and the ones that are only run in the pipeline; great idea, thanks to @nmerget.

Fixes https://github.com/db-ui/core/issues/330

Even also needed to revert the previous version of this change that I've incorrectly provided with https://github.com/db-ui/core/pull/332 instead of this PR.