### PR TITLE
chore(intropage): simple headline/icon adjustment

### DIFF
--- a/source/css/pattern-scaffolding-project-specific.scss
+++ b/source/css/pattern-scaffolding-project-specific.scss
@@ -76,7 +76,7 @@ pl-iframe {
 .tpl-intro [src^="../../images/db-ui-"] {
 	float: left;
 	margin-right: to-rem($pxValue: 4);
-	margin-top: to-rem($pxValue: 28);
+	margin-top: to-rem($pxValue: 21);
 }
 
 .pl-c-typeahead__input {


### PR DESCRIPTION
Currently the vertical alignment of headline and products logo are off and need a slight adjustment on the intro page.