### PR TITLE
Remove clearfix from header

### DIFF
--- a/source/_patterns/03-areas/00-header/header.scss
+++ b/source/_patterns/03-areas/00-header/header.scss
@@ -3,7 +3,6 @@
 @import "../../../css/helpers/functions";
 
 .rea-header {
-	@include clearfix($partial: $partial);
 	background-color: $header---backgroundColor;
 	box-shadow: $header---boxShadow;
 	display: flex;


### PR DESCRIPTION
None of the child elements in header use floats, so the clearfix should be safely removable, fixing part of the problem in https://github.com/db-ui/elements/issues/1210