### PR TITLE
fix: removed duplicated CI/CD activity

### DIFF
--- a/.github/workflows/01-test.yml
+++ b/.github/workflows/01-test.yml
@@ -14,9 +14,6 @@ jobs:
       - name: 🔄 Init Cache
         uses: ./.github/actions/npm-cache
 
-      - name: ⚡ Run Lint
-        run: npm run lint
-
       - name: ⚡ Run Test
         run: npm run test
 


### PR DESCRIPTION
Resolves https://github.com/db-ui/core/issues/415

We're always depending on linting in combination with testing, so we could easily remove running the `lint` script within the `test` workflow:
- https://github.com/db-ui/core/blob/main/.github/workflows/release.yml#L36
- https://github.com/db-ui/core/blob/main/.github/workflows/default.yml#L46
- https://github.com/db-ui/core/blob/main/.github/workflows/default.yml#L51

This would speed up the test step by approx. 17 seconds.