### PR TITLE
fix: incorrectly not inheriting values within `details` elements

### DIFF
--- a/source/_patterns/00-base/_init.scss
+++ b/source/_patterns/00-base/_init.scss
@@ -1,6 +1,6 @@
 // Box sizing
 html {
-	box-sizing: var(--box-sizing, border-box);
+	box-sizing: var(--db-box-sizing, border-box);
 }
 
 *,
@@ -68,10 +68,10 @@ nav,
 }
 
 // Incorrect details/summary box-sizing / most likely a browser bug
-details[class|="cmp"] {
+details {
 	& > *,
 	& > ::before,
 	& > ::after {
-		box-sizing: var(--box-sizing, border-box);
+		box-sizing: var(--db-box-sizing, border-box);
 	}
 }

--- a/source/_patterns/00-base/_init.scss
+++ b/source/_patterns/00-base/_init.scss
@@ -67,7 +67,7 @@ nav,
 	}
 }
 
-// Incorrect details/summary box-sizing / most likely a browser bug
+// details/summary box-sizing / https://kittygiraudel.com/2021/08/23/shadow-roots-and-inheritance/
 details {
 	& > *,
 	& > ::before,

--- a/source/_patterns/00-base/_init.scss
+++ b/source/_patterns/00-base/_init.scss
@@ -1,6 +1,6 @@
 // Box sizing
 html {
-	box-sizing: border-box;
+	box-sizing: var(--box-sizing, border-box);
 }
 
 *,
@@ -64,5 +64,14 @@ nav,
 
 	li::marker {
 		color: $db-color-red-500;
+	}
+}
+
+// Incorrect details/summary box-sizing / most likely a browser bug
+details[class|="cmp"] {
+	& > *,
+	& > ::before,
+	& > ::after {
+		box-sizing: var(--box-sizing, border-box);
 	}
 }


### PR DESCRIPTION
Resolves https://github.com/db-ui/core/issues/494

Introducing a CSS variable to still be able to overwrite the `box-sizing` value (which is the spirit of this whole thing), instead of e.g. "redeclaring" the following:
```css
details {
	& > *,
	& > ::before,
	& > ::after {
		box-sizing: border-box;
	}
}
```

but doing the following instead:

https://github.com/db-ui/core/pull/495/files#diff-3c4b77e29eed06d8c4323c5b88e5e8bd3c78b0c2e077cda82f83eef04836614fR69-R77

more information on the problem:
https://kittygiraudel.com/2021/08/23/shadow-roots-and-inheritance/ & https://stackoverflow.com/questions/75347448/box-sizing-not-inherited-through-details-element

See also https://github.com/db-ui/mono/pull/1205