### PR TITLE
refactor(`lint staged`): added further `xo` supported filetypes

### DIFF
--- a/.lintstagedrc
+++ b/.lintstagedrc
@@ -2,6 +2,6 @@
 	"*.hbs": "npm run lint:html",
 	"*.md": "markdownlint -c .markdown-lint.yml",
 	"*.{css,scss}": "stylelint --fix",
-	"*.{js,ts,tsx}": "xo --fix",
-	"!*.{js,ts,tsx}": "prettier --write --ignore-unknown"
+	"*.{js,ts,tsx,jsx,mjs,cjs}": "xo --fix",
+	"!*.{js,ts,tsx,jsx,mjs,cjs}": "prettier --write --ignore-unknown"
 }


### PR DESCRIPTION
Adding further file types to the lint staged config regarding xo testing: https://www.npmjs.com/package/xo#extensions

We don't need to enhance the list of filetypes for `xo`, as they are already included in the config (but not in documentation): https://github.com/xojs/xo/blob/37e14580c275a15fa36435d0cda7d45d3c515828/lib/constants.js#L24-L37