### PR TITLE
fix: no `html-validate` on hbs filetypes

### DIFF
--- a/.lintstagedrc
+++ b/.lintstagedrc
@@ -1,5 +1,4 @@
 {
-	"*.hbs": "npm run lint:html",
 	"*.md": "markdownlint -c .markdown-lint.yml",
 	"*.{css,scss}": "stylelint --fix",
 	"*.{js,ts,tsx,jsx,mjs,cjs}": "xo --fix",


### PR DESCRIPTION
We shouldn't run `html-validate` on staged `.hbs` files, as the `lint:html` would always mean a full build and testing on all resulting files.