### PR TITLE
fix(dropdown): icon not displaying on Safari

### DIFF
--- a/source/_patterns/00-base/icons/_icons.helpers.scss
+++ b/source/_patterns/00-base/icons/_icons.helpers.scss
@@ -31,8 +31,10 @@
 		}
 
 		content: var(--icon-glyph-#{$position});
-		// Hiding icon from screenreaders
-		content: var(--icon-glyph-#{$position}) / ""; // https://www.w3.org/TR/css-content-3/#alt
+		@supports (content: ""/"") {
+			// Hiding icon from screenreaders
+			content: var(--icon-glyph-#{$position}) / ""; // https://www.w3.org/TR/css-content-3/#alt
+		}
 
 		@if $partial {
 			display: inline-block;


### PR DESCRIPTION
Due a bug within `summary` handling of pseudo elements with an alternative part defined by the simplification out of https://github.com/db-ui/core/pull/709 the icon within dropdown and overflow menu wouldn't get displayed currently.