### PR TITLE
fix(chips): use built-in radiogroup / checkbox behavior for a11y

### DIFF
--- a/source/_patterns/01-elements/chips/_chip.hbs
+++ b/source/_patterns/01-elements/chips/_chip.hbs
@@ -1,6 +1,5 @@
 {{! TODO: This would need to get enhanced later on by the additional possible attributes }}
 {{#if selection}}
-	<!-- [html-validate-disable-next input-missing-label -- label get read out on the input field already and could get aria hidden] -->
 	<input
 		class="elm-chip"
 		type="radio"
@@ -8,7 +7,6 @@
 		name="{{ name }}"
 		data-type="selection"
 		{{#if disabled }} disabled{{/if }}>
-	<!-- [html-validate-disable-next prefer-native-element -- TODO: Evaluate again on this HTML] -->
 	<label
 		for="chip-single-{{ variant }}{{ id-suffix }}"
 		{{#if variant }} data-variant="{{ variant }}"{{/if }}
@@ -16,14 +14,12 @@
 		{{#if iconAfter }} data-icon-after="{{ iconAfter }}"{{/if }}
 		>{{ label }}</label>
 {{else}}
-	<!-- [html-validate-disable-next input-missing-label -- label get read out on the input field already and could get aria hidden] -->
 	<input
 		class="elm-chip"
 		type="checkbox"
 		id="chip-multiple{{#if disabled }}-disabled{{/if}}-{{ variant }}{{ id-suffix }}"
 		data-type="filter"
 		{{#if disabled }} disabled{{/if }}>
-	<!-- [html-validate-disable-next prefer-native-element -- TODO: Evaluate again on this HTML] -->
 	<label
 		for="chip-multiple{{#if disabled }}-disabled{{/if}}-{{ variant }}{{ id-suffix }}"
 		{{#if variant }} data-variant="{{ variant }}"{{/if }}

--- a/source/_patterns/01-elements/chips/_chip.hbs
+++ b/source/_patterns/01-elements/chips/_chip.hbs
@@ -11,29 +11,23 @@
 	<!-- [html-validate-disable-next prefer-native-element -- TODO: Evaluate again on this HTML] -->
 	<label
 		for="chip-single-{{ variant }}{{ id-suffix }}"
-		role="button"
 		{{#if variant }} data-variant="{{ variant }}"{{/if }}
 		{{#if icon }} data-icon="{{ icon }}"{{/if }}
 		{{#if iconAfter }} data-icon-after="{{ iconAfter }}"{{/if }}
-		tabindex="0"
-		aria-hidden="true"
 		>{{ label }}</label>
 {{else}}
 	<!-- [html-validate-disable-next input-missing-label -- label get read out on the input field already and could get aria hidden] -->
 	<input
 		class="elm-chip"
 		type="checkbox"
-		id="chip-multiple-{{ variant }}{{ id-suffix }}"
+		id="chip-multiple{{#if disabled }}-disabled{{/if}}-{{ variant }}{{ id-suffix }}"
 		data-type="filter"
 		{{#if disabled }} disabled{{/if }}>
 	<!-- [html-validate-disable-next prefer-native-element -- TODO: Evaluate again on this HTML] -->
 	<label
-		for="chip-multiple-{{ variant }}{{ id-suffix }}"
-		role="button"
+		for="chip-multiple{{#if disabled }}-disabled{{/if}}-{{ variant }}{{ id-suffix }}"
 		{{#if variant }} data-variant="{{ variant }}"{{/if }}
 		{{#if icon }} data-icon="{{ icon }}"{{/if }}
 		{{#if iconAfter }} data-icon-after="{{ iconAfter }}"{{/if }}
-		tabindex="0"
-		aria-hidden="true"
 		>{{ label }}</label>
 {{/if }}

--- a/source/_patterns/01-elements/chips/_chip.json
+++ b/source/_patterns/01-elements/chips/_chip.json
@@ -1,0 +1,3 @@
+{
+	"label": "Title"
+}

--- a/source/_patterns/01-elements/chips/chip.scss
+++ b/source/_patterns/01-elements/chips/chip.scss
@@ -2,6 +2,8 @@
 
 .elm-chip {
 	& + label {
+		--db-focus-outline-size: max(2px, 0.08em);
+
 		align-items: center;
 		border: solid 1px $db-color-cool-gray-400;
 		border-radius: $chip---radius;
@@ -116,8 +118,20 @@
 		}
 	}
 
+	&:focus-visible {
+		& + label {
+			outline: var(--db-focus-outline-size)
+				var(--db-focus-outline-style, solid)
+				var(--db-focus-outline-color, currentColor);
+			outline-offset: var(
+				--db-focus-outline-offset,
+				var(--db-focus-outline-size)
+			);
+		}
+	}
+
 	&[type="checkbox"],
 	&[type="radio"] {
-		display: none;
+		@include a11y-visually-hidden($partial: $partial);
 	}
 }

--- a/source/_patterns/01-elements/chips/chip.scss
+++ b/source/_patterns/01-elements/chips/chip.scss
@@ -1,3 +1,4 @@
+@import "../../../css/partials.meta";
 @import "chip.variables";
 
 .elm-chip {


### PR DESCRIPTION
Chips are composed of a `checkbox`/`radio` input and a label. As of now, the input is hidden entirely from screenreaders via `display: none` and the label has `role=button`, `aria-hidden=true` and is focusable via `tabindex=0`, though the latter is only true in the `core` examples, not in `db-ui/elements`*.

### Problems:

- In db-ui/elements, chips are not focusable at all! The input is hidden and the label is not focusable
- In db-ui/core, chip labels can be focused. But they can't be interacted with! They have role=button, but no keydown event handlers
- The labels (that act as buttons) have no explicit focus styles – though the user agent might automatically apply some (in Edge: a black outline)
- When a screenreader is active, interaction *can* work. Windows Narrator seems to dispatch `click` despite the missing keyboard event handlers. But I'm not sure if all screenreaders do this (I only tested with Windows Narrator), and also this means interaction via keyboard is inconsistent and works with an active screenreader, but doesn't work without one
- There's no selected state and no information about the different behavior, I don't know which options are selected and whether selecting one chip de-selects the others

### Suggestion

I'd suggest to keep radiogroup (interactiontype=selection) or group (interactiontype=filter) semantics for a set of chips, which is achieved by keeping the input in the a11y tree as the focusable element (only hide it visually) and using the label for the visual style. This way:

- chips (their inputs) are focusable in both `core` and `elements`
- there is consistent visual feedback when a chip is focused
- keyboard navigation (via arrow keys for selection/radiogroup usage, via tab for filter/checkbox usage) works with and without an active screenreader
- screenreaders can provide more useful information for each chip, like its checked state, the control type or something like "Food & Drinks, element 4 of 7"

Recommended usage:

```html
<div role="radiogroup" aria-labelledby="selection-label">
  <span id="selection-label">Select a drink:</span>
  <db-chip interactiontype="selection" name="drink-select" selected>Water</db-chip>
  <db-chip interactiontype="selection" name="drink-select">Wine</db-chip>
  <db-chip interactiontype="selection" name="drink-select">Juice</db-chip>
</div>
```
```html
<div role="group" aria-labelledby="filter-label">
  <span id="filter-label">Filter drinks:</span>
  <db-chip interactiontype="filter" name="drink-filter">Water</db-chip>
  <db-chip interactiontype="filter" name="drink-filter">Wine</db-chip>
  <db-chip interactiontype="filter" name="drink-filter">Juice</db-chip>
</div>
```

### Downsides:

Filter and selection chips visually look the same, but are controlled differently: filter chips are a group of checkboxes, meaning the chips can be individually navigated to through Tab and then activated through space/enter, and selection chips are a radiogroup, where the whole group is navigated to through Tab, and then you can switch between the options with the arrow keys. But that's just using built-in radiogroup and checkbox semantics and is announced as such, so I think that's okay?

### Alternatives considered:

1. Implement the set of chips as proper `listbox` with custom event handlers, `aria-selected` state etc.
2. Keep current behavior of chips acting as buttons, but add consistent focus styles and a keydown handler triggering `this.click()` and make `label[role=button"]` focusable in db-ui/elements, too

The first is a lot of effort and with the second the elements still lack selected state and other relevant info.

fix #694
fix #13

Related: https://github.com/db-ui/elements/pull/2659 