### PR TITLE
refactor: fix scss warnings

### DIFF
--- a/source/_patterns/00-base/icons/_icons.helpers.scss
+++ b/source/_patterns/00-base/icons/_icons.helpers.scss
@@ -37,32 +37,34 @@
 		}
 
 		@if $partial {
-			display: inline-block;
-			/*** icon - partial ***/
-			// * use !important to prevent issues with browser extensions that change fonts
-			font-family: var(--icon-font-family) !important;
-			font-style: normal;
-			font-variant: normal;
+			& {
+				display: inline-block;
+				/*** icon - partial ***/
+				// * use !important to prevent issues with browser extensions that change fonts
+				font-family: var(--icon-font-family) !important;
+				font-style: normal;
+				font-variant: normal;
 
-			font-weight: normal; // CSS variables fallback
-			font-weight: var(--icon-font-weight, normal);
-			line-height: 1;
-			text-transform: none;
-			vertical-align: middle;
+				font-weight: normal; // CSS variables fallback
+				font-weight: var(--icon-font-weight, normal);
+				line-height: 1;
+				text-transform: none;
+				vertical-align: middle;
 
-			/* stylelint-disable */
-			// * Better Font Rendering ===========
-			-webkit-font-smoothing: antialiased;
-			-moz-osx-font-smoothing: grayscale;
-			/* stylelint-enable */
+				/* stylelint-disable */
+				// * Better Font Rendering ===========
+				-webkit-font-smoothing: antialiased;
+				-moz-osx-font-smoothing: grayscale;
+				/* stylelint-enable */
 
-			// Hiding icon from screenreaders
-			/* stylelint-disable */
-			-webkit-alt: "";
-			/* stylelint-enable */
-			alt: "";
-			speak: none; // Hiding icon from screenreaders, fallback by older notation
-			speak: never; // Hiding icon from screenreaders
+				// Hiding icon from screenreaders
+				/* stylelint-disable */
+				-webkit-alt: "";
+				/* stylelint-enable */
+				alt: "";
+				speak: none; // Hiding icon from screenreaders, fallback by older notation
+				speak: never; // Hiding icon from screenreaders
+			}
 			@media aural {
 				content: none;
 			}
@@ -77,7 +79,9 @@
 
 // SCSS mixin for elements that text should get hidden in favour of only displaying the included icon
 @mixin is-icon-text-replace($position: "before") {
-	font-size: 0;
+	& {
+		font-size: 0;
+	}
 
 	@if $position == "before" {
 		&::before {

--- a/source/_patterns/00-base/icons/_icons.helpers.scss
+++ b/source/_patterns/00-base/icons/_icons.helpers.scss
@@ -8,7 +8,9 @@
 ) {
 	// We're setting this on the parent tag, so that it could get overwritten via data-icon=*
 	@if $glyph != "" {
-		--icon-glyph-#{$position}: "#{$glyph}";
+		& {
+			--icon-glyph-#{$position}: "#{$glyph}";
+		}
 	}
 
 	&::#{$position} {

--- a/source/_patterns/01-elements/checkbox/checkbox.scss
+++ b/source/_patterns/01-elements/checkbox/checkbox.scss
@@ -10,10 +10,6 @@
 		#{to-rem($pxValue: 24)}
 	);
 
-	@extend %form-element-enhanced-clickable-area;
-
-	@include icon("\00A0", 24, "outline", $partial: $partial);
-
 	align-content: center;
 
 	appearance: none;
@@ -26,6 +22,11 @@
 	height: var(--db-form-element-dimensions);
 	justify-content: center;
 	width: var(--db-form-element-dimensions);
+
+	& {
+		@extend %form-element-enhanced-clickable-area;
+		@include icon("\00A0", 24, "outline", $partial: $partial);
+	}
 
 	&[type="checkbox"] {
 		vertical-align: top;

--- a/source/_patterns/01-elements/checkbox/checkbox.scss
+++ b/source/_patterns/01-elements/checkbox/checkbox.scss
@@ -13,6 +13,7 @@
 	@extend %form-element-enhanced-clickable-area;
 
 	@include icon("\00A0", 24, "outline", $partial: $partial);
+
 	align-content: center;
 
 	appearance: none;

--- a/source/_patterns/01-elements/select/select.scss
+++ b/source/_patterns/01-elements/select/select.scss
@@ -15,11 +15,6 @@
 
 	// Style the regular (non-multiple) select elements
 	&:not([multiple]) {
-		// Semitransparent is the default style
-		@at-root :where(#{&}) {
-			@extend %form-element-semitransparent;
-		}
-
 		background-image: var(
 			--db-ic-expand-more-20,
 			url(#{$icons-path}functional/images/navigation/db_ic_expand_more_20.svg)
@@ -28,6 +23,12 @@
 		background-repeat: no-repeat;
 		height: to-rem($pxValue: 44);
 		padding: to-rem($pxValue: 20) to-rem($pxValue: 42) 0 $db-spacing-m;
+
+		// Semitransparent is the default style
+		@at-root :where(#{&}) {
+			@extend %form-element-semitransparent;
+		}
+
 		// No need to reposition the included value on hidden label
 		&:has(+ label[data-label-hidden="true"]) {
 			padding-top: 0;

--- a/source/_patterns/01-elements/textarea/textarea.scss
+++ b/source/_patterns/01-elements/textarea/textarea.scss
@@ -7,11 +7,6 @@
 .elm-textarea {
 	@extend %form-element;
 
-	// Semitransparent is the default style
-	@at-root :where(#{&}) {
-		@extend %form-element-semitransparent;
-	}
-
 	display: block;
 
 	font-size: to-rem($pxValue: 16);
@@ -24,6 +19,11 @@
 	resize: vertical;
 
 	width: 100%;
+
+	// Semitransparent is the default style
+	@at-root :where(#{&}) {
+		@extend %form-element-semitransparent;
+	}
 
 	// * to be evaluated
 	// display: inline-flex;

--- a/source/_patterns/02-components/accordion/accordion.scss
+++ b/source/_patterns/02-components/accordion/accordion.scss
@@ -8,13 +8,6 @@
 	padding-right: $accordion---paddingRight;
 
 	summary {
-		@include icon(
-			glyph(expand-more),
-			24,
-			"outline",
-			"after",
-			$partial: $partial
-		);
 		align-items: center;
 		display: flex;
 		justify-content: space-between;
@@ -25,6 +18,16 @@
 		width: calc(
 			100% + var(--db-accordion---paddingLeft) + #{$accordion---paddingRight}
 		);
+
+		& {
+			@include icon(
+				glyph(expand-more),
+				24,
+				"outline",
+				"after",
+				$partial: $partial
+			);
+		}
 
 		// Replace existing marker with an icon from the library
 		&::-webkit-details-marker {

--- a/source/_patterns/02-components/dialog/dialog.scss
+++ b/source/_patterns/02-components/dialog/dialog.scss
@@ -70,11 +70,19 @@
 
 		.elm-link {
 			&.is-close {
-				@include icon(glyph(close), 24, "outline", $partial: $partial);
-				@include is-icon-text-replace();
 				position: absolute;
 				right: 0;
 				top: 0;
+
+				& {
+					@include icon(
+						glyph(close),
+						24,
+						"outline",
+						$partial: $partial
+					);
+					@include is-icon-text-replace();
+				}
 			}
 		}
 	}

--- a/source/_patterns/02-components/dialog/dialog.scss
+++ b/source/_patterns/02-components/dialog/dialog.scss
@@ -72,7 +72,6 @@
 			&.is-close {
 				@include icon(glyph(close), 24, "outline", $partial: $partial);
 				@include is-icon-text-replace();
-
 				position: absolute;
 				right: 0;
 				top: 0;

--- a/source/_patterns/02-components/language-switcher/language-switcher.scss
+++ b/source/_patterns/02-components/language-switcher/language-switcher.scss
@@ -95,14 +95,17 @@
 
 			.elm-link,
 			.elm-button {
-				@include icon(
-					glyph(expand-more),
-					24,
-					"outline",
-					"after",
-					$partial: $partial
-				);
 				padding-bottom: to-rem($pxValue: 22);
+
+				& {
+					@include icon(
+						glyph(expand-more),
+						24,
+						"outline",
+						"after",
+						$partial: $partial
+					);
+				}
 
 				&:hover {
 					color: $db-color-red-500;

--- a/source/_patterns/02-components/language-switcher/language-switcher.scss
+++ b/source/_patterns/02-components/language-switcher/language-switcher.scss
@@ -102,7 +102,6 @@
 					"after",
 					$partial: $partial
 				);
-
 				padding-bottom: to-rem($pxValue: 22);
 
 				&:hover {

--- a/source/_patterns/02-components/link-list/link-list.scss
+++ b/source/_patterns/02-components/link-list/link-list.scss
@@ -8,9 +8,12 @@
 
 	li {
 		.elm-link {
-			@include icon(glyph(chevron-right), $partial: $partial);
 			font-weight: 700;
 			text-decoration: none;
+
+			& {
+				@include icon(glyph(chevron-right), $partial: $partial);
+			}
 
 			&:hover,
 			&:active {

--- a/source/_patterns/02-components/link-list/link-list.scss
+++ b/source/_patterns/02-components/link-list/link-list.scss
@@ -9,7 +9,6 @@
 	li {
 		.elm-link {
 			@include icon(glyph(chevron-right), $partial: $partial);
-
 			font-weight: 700;
 			text-decoration: none;
 

--- a/source/_patterns/02-components/mainnavigation/mainnavigation.scss
+++ b/source/_patterns/02-components/mainnavigation/mainnavigation.scss
@@ -40,7 +40,6 @@
 	& > label[for] {
 		@include icon(glyph(menu), 24, "outline", $partial: $partial);
 		@include icon(glyph(close), 24, "outline", "after", $partial: $partial);
-
 		background-color: $header---backgroundColor; // TODO: This would need to get replaced by the correct (semantic) color
 
 		border-bottom: 1px solid $db-color-warm-gray-100;

--- a/source/_patterns/02-components/mainnavigation/mainnavigation.scss
+++ b/source/_patterns/02-components/mainnavigation/mainnavigation.scss
@@ -38,14 +38,23 @@
 	}
 
 	& > label[for] {
-		@include icon(glyph(menu), 24, "outline", $partial: $partial);
-		@include icon(glyph(close), 24, "outline", "after", $partial: $partial);
 		background-color: $header---backgroundColor; // TODO: This would need to get replaced by the correct (semantic) color
 
 		border-bottom: 1px solid $db-color-warm-gray-100;
 
 		display: block;
 		padding: to-rem($pxValue: 8) to-rem($pxValue: 22) to-rem($pxValue: 10);
+
+		& {
+			@include icon(glyph(menu), 24, "outline", $partial: $partial);
+			@include icon(
+				glyph(close),
+				24,
+				"outline",
+				"after",
+				$partial: $partial
+			);
+		}
 
 		&::before {
 			margin-right: to-rem($pxValue: 16);

--- a/source/_patterns/02-components/overflow-menu/overflow-menu.scss
+++ b/source/_patterns/02-components/overflow-menu/overflow-menu.scss
@@ -19,7 +19,6 @@
 			"outline",
 			$partial: $partial
 		);
-
 		display: inline-block;
 
 		&::before {

--- a/source/_patterns/02-components/overflow-menu/overflow-menu.scss
+++ b/source/_patterns/02-components/overflow-menu/overflow-menu.scss
@@ -13,13 +13,16 @@
 	}
 
 	summary {
-		@include icon(
-			$cmp-overflow-menu-icon,
-			20,
-			"outline",
-			$partial: $partial
-		);
 		display: inline-block;
+
+		& {
+			@include icon(
+				$cmp-overflow-menu-icon,
+				20,
+				"outline",
+				$partial: $partial
+			);
+		}
 
 		&::before {
 			display: inline-block;

--- a/source/_patterns/02-components/sitesearch/sitesearch.scss
+++ b/source/_patterns/02-components/sitesearch/sitesearch.scss
@@ -29,8 +29,11 @@
 	}
 
 	.elm-label {
-		@include icon(glyph(search), 24, "outline", $partial: $partial);
 		display: inline-block;
+
+		& {
+			@include icon(glyph(search), 24, "outline", $partial: $partial);
+		}
 
 		&::before {
 			// TODO: Evaluate on whether this declaration could get moved to the general icon declarations
@@ -50,12 +53,15 @@
 	}
 
 	.elm-button {
-		@include icon(glyph(search), 24, "outline", $partial: $partial);
 		display: none;
 		left: 0;
 		position: absolute;
 		top: to-em($pxValue: 8);
 		visibility: hidden;
+
+		& {
+			@include icon(glyph(search), 24, "outline", $partial: $partial);
+		}
 
 		&::before {
 			left: to-rem($pxValue: 4);

--- a/source/_patterns/02-components/sitesearch/sitesearch.scss
+++ b/source/_patterns/02-components/sitesearch/sitesearch.scss
@@ -30,7 +30,6 @@
 
 	.elm-label {
 		@include icon(glyph(search), 24, "outline", $partial: $partial);
-
 		display: inline-block;
 
 		&::before {
@@ -52,7 +51,6 @@
 
 	.elm-button {
 		@include icon(glyph(search), 24, "outline", $partial: $partial);
-
 		display: none;
 		left: 0;
 		position: absolute;

--- a/source/_patterns/03-areas/00-header/meta.scss
+++ b/source/_patterns/03-areas/00-header/meta.scss
@@ -29,8 +29,11 @@
 
 	& > .elm-link {
 		&[rel="account"] {
-			@include is-icon-text-replace();
 			margin-left: to-rem($pxValue: 4);
+
+			& {
+				@include is-icon-text-replace();
+			}
 
 			@media screen and (min-width: #{($header-srOnly-linkAccount-breakpoint + 1)}rem) {
 				margin-left: to-rem($pxValue: 8);

--- a/source/_patterns/03-areas/00-header/meta.scss
+++ b/source/_patterns/03-areas/00-header/meta.scss
@@ -30,15 +30,10 @@
 	& > .elm-link {
 		&[rel="account"] {
 			@include is-icon-text-replace();
-
 			margin-left: to-rem($pxValue: 4);
 
 			@media screen and (min-width: #{($header-srOnly-linkAccount-breakpoint + 1)}rem) {
 				margin-left: to-rem($pxValue: 8);
-			}
-
-			@media screen and (max-width: #{($header-srOnly-linkAccount-breakpoint)}rem) {
-				@include is-icon-text-replace();
 			}
 		}
 	}

--- a/source/_patterns/03-areas/03-footer/footer.scss
+++ b/source/_patterns/03-areas/03-footer/footer.scss
@@ -6,7 +6,6 @@
 
 .rea-footer {
 	@include clearfix($partial: $partial);
-
 	background-color: $footer---backgroundColor;
 	box-shadow: $footer---boxShadow;
 

--- a/source/_patterns/03-areas/03-footer/footer.scss
+++ b/source/_patterns/03-areas/03-footer/footer.scss
@@ -5,13 +5,16 @@
 @import "footer.variables";
 
 .rea-footer {
-	@include clearfix($partial: $partial);
 	background-color: $footer---backgroundColor;
 	box-shadow: $footer---boxShadow;
 
 	color: $db-color-cool-gray-500;
 	margin-top: $footer---marginTop;
 	padding: #{to-rem($pxValue: 21)} #{to-rem($pxValue: 16)};
+
+	& {
+		@include clearfix($partial: $partial);
+	}
 
 	&.has-border {
 		border-top: $footer---borderTop;


### PR DESCRIPTION
> Deprecation Warning: Sass's behavior for declarations that appear after nested
rules will be changing to match the behavior specified by CSS in an upcoming
version. To keep the existing behavior, move the declaration above the nested
rule. To opt into the new behavior, wrap the declaration in `& {}`.

> More info: https://sass-lang.com/d/mixed-decls