### PR TITLE
refactor: aligned lint fixing

### DIFF
--- a/.config/.lintstagedrc.json
+++ b/.config/.lintstagedrc.json
@@ -1,5 +1,5 @@
 {
-	"*.md": "markdownlint -c .markdown-lint.yml",
+	"*.md": "markdownlint -c .markdown-lint.yml --fix",
 	".stylelintrc.*": "stylelint --validate --allow-empty-input",
 	"stylelint.config.*": "stylelint --validate --allow-empty-input",
 	"*.{css,scss}": "stylelint --fix --allow-empty-input --no-validate",


### PR DESCRIPTION
as the other linting / codestyle tools like `prettier` and `stylelint` are fixing the problems right away, we should active this as well for markdownlint.