### PR TITLE
fix(dependabot): added explicit `patterns` definition for patch group

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -26,6 +26,8 @@ updates:
       patch-dependencies:
         update-types:
           - "patch"
+        patterns:
+          - "*"
       commitlint:
         patterns:
           - "@commitlint*"


### PR DESCRIPTION
We are expecting this to fix the currently not being grouped named dependencies.