### PR TITLE
fix: Return typed values from scss functions instead of strings

### DIFF
--- a/source/css/helpers/_functions.scss
+++ b/source/css/helpers/_functions.scss
@@ -1,10 +1,10 @@
 @import "../db-ui-core.variables";
 
 @function to-rem($pxValue) {
-	@return #{$pxValue * $dbBaseFontSizeSass}rem;
+	@return ($pxValue * $dbBaseFontSizeSass) * 1rem;
 }
 @function to-em($pxValue) {
-	@return #{$pxValue * $dbBaseFontSizeSass}em;
+	@return ($pxValue * $dbBaseFontSizeSass) * 1rem;
 }
 
 // Mixin wrappers around the SCSS placeholders


### PR DESCRIPTION
The `px-to-rem()` and `px-to-em()` functions returned strings via interpolation (`#{...}rem`), preventing calculations with their output. Changed to return properly typed values by multiplying the numeric result by `1rem`/`1em`.

adapted from https://github.com/db-ux-design-system/core-web/pull/5570